### PR TITLE
Add group-title to playlist by AU state/region

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,40 @@
-# IPTV AU for Docker / Channels
+# IPTV AU for Docker
 
-https://www.matthuisman.nz/....
+Australian free-to-air IPTV proxy. Serves an M3U8 playlist and EPG from [i.mjh.nz](https://i.mjh.nz).
+
+## Run
+
+```yaml
+services:
+  iptv-au:
+    image: matthuisman/iptv-au
+    environment:
+      - REGION=all  # or: nsw, vic, qld, sa, wa, tas, nt, act
+    ports:
+      - 8183:80
+    restart: unless-stopped
+```
+
+## Endpoints
+
+| URL | Description |
+|-----|-------------|
+| `http://host:8183/playlist.m3u8` | M3U8 playlist |
+| `http://host:8183/tvh.m3u8` | TvHeadend playlist (ffmpeg pipe) |
+| `http://host:8183/epg.xml` | XMLTV EPG |
+| `http://host:8183/clear_cache` | Clear cached data |
+
+## Playlist query params
+
+| Param | Example | Description |
+|-------|---------|-------------|
+| `sort` | `sort=name` | Sort by name (default: channel number) |
+| `start_chno` | `start_chno=1000` | Override starting channel number |
+| `include` | `include=iptv-au-abc1\|iptv-au-sbs` | Whitelist channels by ID |
+| `exclude` | `exclude=iptv-au-abc1\|iptv-au-sbs` | Blacklist channels by ID |
+
+## Notes
+
+- Cache defaults to 5 minutes, override with `CACHE_TIME` env var
+- DRM/licensed channels are excluded automatically
+- Channels are grouped by state (e.g. `AU| VIC`, `AU| NSW`) or `AU| FREE TO AIR` for national streams

--- a/app.py
+++ b/app.py
@@ -11,6 +11,8 @@ from socketserver import ThreadingMixIn
 from base64 import b64encode, b64decode
 from urllib.parse import urlparse, parse_qsl, urlencode, unquote, parse_qs
 
+import re
+
 import requests
 from cachelib import SimpleCache
 
@@ -261,8 +263,12 @@ class Handler(BaseHTTPRequestHandler):
                 if tags:
                     tags = '\n' + tags
 
+            # Derive group from slug region suffix, fall back to national
+            m = re.search(r'-(nsw|vic|qld|sa|wa|tas|nt|act)(-|$)', slug, re.I)
+            group = f'AU| {m.group(1).upper()}' if m else 'AU| FREE TO AIR'
+
             # Write channel information
-            self.wfile.write(f'#EXTINF:-1 channel-id="{channel_id}" tvg-id="{slug}" tvg-logo="{logo}"{chno},{name}{tags}\n{url}\n\n'.encode('utf8'))
+            self.wfile.write(f'#EXTINF:-1 channel-id="{channel_id}" tvg-id="{slug}" tvg-logo="{logo}"{chno} group-title="{group}",{name}{tags}\n{url}\n\n'.encode('utf8'))
 
     def _epg(self):
         url = EPG_URL.format(region=REGION)

--- a/app.py
+++ b/app.py
@@ -263,9 +263,20 @@ class Handler(BaseHTTPRequestHandler):
                 if tags:
                     tags = '\n' + tags
 
-            # Derive group from slug region suffix, fall back to national
+            # Derive group from slug region/city suffix, fall back to national
+            _CITY_STATE = {
+                'mel': 'VIC', 'syd': 'NSW', 'bri': 'QLD', 'ade': 'SA', 'per': 'WA',
+                'cns': 'QLD', 'tsv': 'QLD', 'mky': 'QLD', 'rky': 'QLD',
+                'wby': 'QLD', 'twb': 'QLD', 'ssc': 'QLD', 'coast': 'QLD',
+                'newcastle': 'NSW', 'lismore': 'NSW', 'mountains': 'NSW',
+            }
             m = re.search(r'-(nsw|vic|qld|sa|wa|tas|nt|act)(-|$)', slug, re.I)
-            group = f'AU| {m.group(1).upper()}' if m else 'AU| FREE TO AIR'
+            if m:
+                state = m.group(1).upper()
+            else:
+                city = slug.split('-')[-1].lower()
+                state = _CITY_STATE.get(city)
+            group = f'AU| {state}' if state else 'AU| FREE TO AIR'
 
             # Write channel information
             self.wfile.write(f'#EXTINF:-1 channel-id="{channel_id}" tvg-id="{slug}" tvg-logo="{logo}"{chno} group-title="{group}",{name}{tags}\n{url}\n\n'.encode('utf8'))

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,10 @@
 services:
   iptv-au:
     container_name: iptv-au
-    image: matthuisman/iptv-au
+    build:
+      context: .
+      dockerfile: Dockerfile
+    pull_policy: build
     environment:
       - REGION=all
     ports:


### PR DESCRIPTION
## What

Adds `group-title` tags to the M3U8 playlist so channels are grouped by Australian state.

- Regional channels are grouped by state: `AU| NSW`, `AU| VIC`, `AU| QLD`, `AU| SA`, `AU| WA`, `AU| TAS`, `AU| NT`, `AU| ACT`
- City-based slugs (e.g. `-mel`, `-syd`, `-bri`, `-per`, `-ade`) are mapped to their state
- QLD regional cities (`cns`, `tsv`, `mky`, `rky`, `wby`, `twb`, `ssc`) are mapped to `AU| QLD`
- National/streaming channels fall back to `AU| FREE TO AIR`

## Why

Without `group-title`, all channels land in a single default group in IPTV clients (Dispatcharr, Kodi, etc.), making it hard to browse by region.